### PR TITLE
Add type hints and documentation

### DIFF
--- a/gs_run.sh
+++ b/gs_run.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+# Train a Gaussian Splatting model and render results for each scene
+
 output_dir="./gaussian_output"
 output_video_dir="./gaussian_output_video"
 # scenes=("double_lift_cloth_1" "double_lift_cloth_3" "double_lift_sloth" "double_lift_zebra"
@@ -10,17 +14,18 @@ output_video_dir="./gaussian_output_video"
 #         "single_push_sloth"
 #         "weird_package")
 
-scenes=("double_stretch_sloth")
+scenes=("double_stretch_sloth")  # list of scenes to process
 
 exp_name="init=hybrid_iso=True_ldepth=0.001_lnormal=0.0_laniso_0.0_lseg=1.0"
 
+# Precompute interpolated camera poses
 python ./gaussian_splatting/generate_interp_poses.py
 
 # Iterate over each folder
 for scene_name in "${scenes[@]}"; do
     echo "Processing: $scene_name"
 
-    # Training
+    # Training phase
     python gs_train.py \
         -s ./data/gaussian_data/${scene_name} \
         -m ${output_dir}/${scene_name}/${exp_name} \
@@ -33,12 +38,12 @@ for scene_name in "${scenes[@]}"; do
         --isotropic \
         --gs_init_opt 'hybrid'
 
-    # Rendering
+    # Rendering phase
     python gs_render.py \
         -s ./data/gaussian_data/${scene_name} \
         -m ${output_dir}/${scene_name}/${exp_name} \
 
-    # Convert images to video
+    # Convert rendered images to a video
     python gaussian_splatting/img2video.py \
         --image_folder ${output_dir}/${scene_name}/${exp_name}/test/ours_10000/renders \
         --video_path ${output_video_dir}/${scene_name}/${exp_name}.mp4

--- a/gs_run_simulate.sh
+++ b/gs_run_simulate.sh
@@ -1,7 +1,11 @@
+#!/bin/bash
+
+# Render dynamic Gaussian splatting sequences and export videos
+
 output_dir="./gaussian_output_dynamic"
 
 # views=("0" "1" "2")
-views=("0")
+views=("0")  # indices of camera views to export
 
 # scenes=("double_lift_cloth_1" "double_lift_cloth_3" "double_lift_sloth" "double_lift_zebra"
 #         "double_stretch_sloth" "double_stretch_zebra"
@@ -13,19 +17,20 @@ views=("0")
 #         "single_push_sloth"
 #         "weird_package")
 
-scenes=("double_stretch_sloth")
+scenes=("double_stretch_sloth")  # scenes to simulate
 
-exp_name='init=hybrid_iso=True_ldepth=0.001_lnormal=0.0_laniso_0.0_lseg=1.0'
+exp_name='init=hybrid_iso=True_ldepth=0.001_lnormal=0.0_laniso_0.0_lseg=1.0'  # experiment directory name
 
 for scene_name in "${scenes[@]}"; do
 
+    # Simulate dynamics and render
     python gs_render_dynamics.py \
         -s ./data/gaussian_data/${scene_name} \
         -m ./gaussian_output/${scene_name}/${exp_name} \
         --name ${scene_name} \
 
     for view_name in "${views[@]}"; do
-        # Convert images to video
+        # Convert rendered frames to video
         python gaussian_splatting/img2video.py \
             --image_folder ${output_dir}/${scene_name}/${view_name} \
             --video_path ${output_dir}/${scene_name}/${view_name}.mp4

--- a/gs_run_simulate_white.sh
+++ b/gs_run_simulate_white.sh
@@ -1,7 +1,11 @@
+#!/bin/bash
+
+# Same as gs_run_simulate.sh but renders on white background
+
 output_dir="./gaussian_output_dynamic_white"
 
 # views=("0" "1" "2")
-views=("0")
+views=("0")  # camera view indices
 
 # scenes=("double_lift_cloth_1" "double_lift_cloth_3" "double_lift_sloth" "double_lift_zebra"
 #         "double_stretch_sloth" "double_stretch_zebra"
@@ -13,12 +17,13 @@ views=("0")
 #         "single_push_sloth"
 #         "weird_package")
 
-scenes=("double_stretch_sloth")
+scenes=("double_stretch_sloth")  # scenes to process
 
-exp_name='init=hybrid_iso=True_ldepth=0.001_lnormal=0.0_laniso_0.0_lseg=1.0'
+exp_name='init=hybrid_iso=True_ldepth=0.001_lnormal=0.0_laniso_0.0_lseg=1.0'  # experiment name
 
 for scene_name in "${scenes[@]}"; do
 
+    # Simulate dynamics with white background
     python gs_render_dynamics.py \
         -s ./data/gaussian_data/${scene_name} \
         -m ./gaussian_output/${scene_name}/${exp_name} \
@@ -27,7 +32,7 @@ for scene_name in "${scenes[@]}"; do
         --output_dir ${output_dir}/${scene_name}
 
     for view_name in "${views[@]}"; do
-        # Convert images to video
+        # Convert rendered frames to video
         python gaussian_splatting/img2video.py \
             --image_folder ${output_dir}/${scene_name}/${view_name} \
             --video_path ${output_dir}/${scene_name}/${view_name}.mp4

--- a/inference_warp.py
+++ b/inference_warp.py
@@ -1,7 +1,8 @@
-from qqtt import InvPhyTrainerWarp
 """Entry point for running the inverse physics model in inference mode."""
 
 from __future__ import annotations
+
+from qqtt import InvPhyTrainerWarp
 
 from qqtt.utils import logger, cfg
 from datetime import datetime
@@ -30,13 +31,15 @@ seed: int = 42
 set_all_seeds(seed)
 
 if __name__ == "__main__":
+    """Run the trained model on the specified dataset for inference."""
+
     parser = ArgumentParser()
     parser.add_argument("--base_path", type=str, required=True)
     parser.add_argument("--case_name", type=str, required=True)
     args = parser.parse_args()
 
-    base_path = args.base_path
-    case_name = args.case_name
+    base_path: str = args.base_path
+    case_name: str = args.case_name
 
     # Select configuration based on the dataset type
     if "cloth" in case_name or "package" in case_name:
@@ -46,7 +49,7 @@ if __name__ == "__main__":
 
     logger.info(f"[DATA TYPE]: {cfg.data_type}")
 
-    base_dir = f"experiments/{case_name}"
+    base_dir: str = f"experiments/{case_name}"
 
     # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"experiments_optimization/{case_name}/optimal_params.pkl"

--- a/interactive_playground.py
+++ b/interactive_playground.py
@@ -1,29 +1,39 @@
-from qqtt import InvPhyTrainerWarp
-from qqtt.utils import logger, cfg
+"""Interactive demo for controlling simulations in real time."""
+
+from __future__ import annotations
+
 from datetime import datetime
-import random
-import numpy as np
-import torch
-from argparse import ArgumentParser
 import glob
+import json
 import os
 import pickle
-import json
+import random
+from argparse import ArgumentParser
 
-def set_all_seeds(seed):
+import numpy as np
+import torch
+
+from qqtt import InvPhyTrainerWarp
+from qqtt.utils import cfg, logger
+
+def set_all_seeds(seed: int) -> None:
+    """Seed all relevant RNGs for reproducibility."""
+
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)  # if you are using multi-GPU.
+    torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
 
 
-seed = 42
+seed: int = 42
 set_all_seeds(seed)
 
 if __name__ == "__main__":
+    """Launch the interactive playground using a trained model."""
+
     parser = ArgumentParser()
     parser.add_argument(
         "--base_path",
@@ -47,15 +57,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    base_path = args.base_path
-    case_name = args.case_name
+    base_path: str = args.base_path
+    case_name: str = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
         cfg.load_from_yaml("configs/cloth.yaml")
     else:
         cfg.load_from_yaml("configs/real.yaml")
 
-    base_dir = f"./temp_experiments/{case_name}"
+    base_dir: str = f"./temp_experiments/{case_name}"
 
     # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"./experiments_optimization/{case_name}/optimal_params.pkl"

--- a/visualize_material.py
+++ b/visualize_material.py
@@ -1,30 +1,40 @@
 # Experimental feature to approximate the materials in the spring-mass model.
-from qqtt import InvPhyTrainerWarp
-from qqtt.utils import logger, cfg
-import random
-import numpy as np
-import torch
-from argparse import ArgumentParser
+"""Script used to visualize learned material parameters."""
+
+from __future__ import annotations
+
 import glob
+import json
 import os
 import pickle
-import json
+import random
+from argparse import ArgumentParser
+
+import numpy as np
+import torch
+
+from qqtt import InvPhyTrainerWarp
+from qqtt.utils import cfg, logger
 
 
-def set_all_seeds(seed):
+def set_all_seeds(seed: int) -> None:
+    """Seed all relevant random number generators."""
+
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)  # if you are using multi-GPU.
+    torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
 
 
-seed = 42
+seed: int = 42
 set_all_seeds(seed)
 
 if __name__ == "__main__":
+    """Entry point for visualizing learned material parameters."""
+
     cfg.load_from_yaml("configs/real.yaml")
 
     parser = ArgumentParser()
@@ -41,15 +51,15 @@ if __name__ == "__main__":
     parser.add_argument("--case_name", type=str, default="double_stretch_sloth")
     args = parser.parse_args()
 
-    base_path = args.base_path
-    case_name = args.case_name
+    base_path: str = args.base_path
+    case_name: str = args.case_name
 
     if "cloth" in case_name or "package" in case_name:
         cfg.load_from_yaml("configs/cloth.yaml")
     else:
         cfg.load_from_yaml("configs/real.yaml")
 
-    base_dir = f"./experiments/{case_name}"
+    base_dir: str = f"./experiments/{case_name}"
 
     # Read the first-satage optimized parameters to set the indifferentiable parameters
     optimal_path = f"./experiments_optimization/{case_name}/optimal_params.pkl"


### PR DESCRIPTION
## Summary
- add comprehensive type hints and comments to utility scripts
- document dynamic and static rendering scripts
- document and clean up bash helper scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ff792fd4832e952410a7944cb7df