### PR TITLE
Add typing and comments to helper scripts

### DIFF
--- a/script_inference.py
+++ b/script_inference.py
@@ -1,17 +1,39 @@
-"""Run inference on all trained experiment folders."""
+"""Run inference for every experiment folder.
+
+Each subdirectory inside ``experiments`` is treated as a trained case.  The
+script invokes ``inference_warp.py`` with the case name so that the final
+trajectory can be generated for each scene.
+"""
 
 from __future__ import annotations
 
 import glob
 import os
-import json
+from typing import List
 
-base_path: str = "./data/different_types"
-dir_names = glob.glob("experiments/*")
-for dir_name in dir_names:
-    case_name = dir_name.split("/")[-1]
 
-    # Launch the inference script for the given case
-    os.system(
-        f"python inference_warp.py --base_path {base_path} --case_name {case_name}"
-    )
+def run_inference(base_path: str, exp_dir: str = "experiments") -> None:
+    """Launch inference on all experiments.
+
+    Parameters
+    ----------
+    base_path:
+        Root path of the data used during training/inference.
+    exp_dir:
+        Directory containing all experiment subfolders.
+    """
+
+    dir_names: List[str] = glob.glob(f"{exp_dir}/*")
+    for dir_name in dir_names:
+        case_name: str = os.path.basename(dir_name)
+
+        # Launch the inference script for the given case.
+        cmd: str = (
+            f"python inference_warp.py --base_path {base_path} --case_name {case_name}"
+        )
+        os.system(cmd)
+
+
+if __name__ == "__main__":
+    run_inference("./data/different_types")
+

--- a/script_optimize.py
+++ b/script_optimize.py
@@ -1,23 +1,49 @@
-"""Script to launch optimization for each scene."""
+"""Utility to launch CMA‑ES optimization for every dataset.
+
+This module iterates over all case folders inside ``base_path`` and invokes
+``optimize_cma.py`` on the second frame of the training split defined in each
+``split.json`` file.
+"""
 
 from __future__ import annotations
 
 import glob
-import os
 import json
+import os
+from typing import List
 
-base_path: str = "./data/different_types"
-dir_names = glob.glob(f"{base_path}/*")
-for dir_name in dir_names:
-    case_name = dir_name.split("/")[-1]
-    
-    # Read the train test split
-    with open(f"{base_path}/{case_name}/split.json", "r") as f:
-        split = json.load(f)
 
-    train_frame = split["train"][1]
+def run_optimization(base_path: str) -> None:
+    """Run CMA-ES optimization for all scenes under ``base_path``.
 
-    # Execute CMA-ES optimization on the selected frame
-    os.system(
-        f"python optimize_cma.py --base_path {base_path} --case_name {case_name} --train_frame {train_frame}"
-    )
+    Parameters
+    ----------
+    base_path:
+        Root directory that contains subdirectories for each scene. Each scene
+        must provide a ``split.json`` file describing the train/test split.
+    """
+
+    # Collect all case directories within ``base_path``.
+    dir_names: List[str] = glob.glob(f"{base_path}/*")
+    for dir_name in dir_names:
+        # Each directory name becomes the case name.
+        case_name: str = os.path.basename(dir_name)
+
+        # Read the training/testing split information.
+        with open(f"{base_path}/{case_name}/split.json", "r", encoding="utf-8") as f:
+            split: dict[str, list[int]] = json.load(f)
+
+        # ``train`` is assumed to be a two-element list; we use the second
+        # element as the frame index for optimization.
+        train_frame: int = split["train"][1]
+
+        # Execute CMA-ES optimization on the selected frame.
+        cmd: str = (
+            f"python optimize_cma.py --base_path {base_path} "
+            f"--case_name {case_name} --train_frame {train_frame}"
+        )
+        os.system(cmd)
+
+
+if __name__ == "__main__":
+    run_optimization("./data/different_types")

--- a/script_process_data.py
+++ b/script_process_data.py
@@ -1,25 +1,46 @@
-import os
+"""Batch data processing based on ``data_config.csv``.
+
+This script iterates over rows in ``data_config.csv`` and calls
+``process_data.py`` for each case.  If ``shape_prior`` is set to ``true`` for a
+case, the ``--shape_prior`` flag is included when invoking ``process_data.py``.
+"""
+
+from __future__ import annotations
+
 import csv
+import os
+from typing import Iterable
 
-base_path = "./data/different_types"
 
-os.system("rm -f timer.log")
+def process_all_cases(base_path: str, config_file: str = "data_config.csv") -> None:
+    """Read ``config_file`` and invoke ``process_data.py`` for each case."""
 
-with open("data_config.csv", newline="", encoding="utf-8") as csvfile:
-    reader = csv.reader(csvfile)
-    for row in reader:
-        case_name = row[0]
-        category = row[1]
-        shape_prior = row[2]
+    # Remove previous timer log if it exists.
+    os.system("rm -f timer.log")
 
-        if not os.path.exists(f"{base_path}/{case_name}"):
-            continue
+    with open(config_file, newline="", encoding="utf-8") as csvfile:
+        reader: Iterable[list[str]] = csv.reader(csvfile)
+        for row in reader:
+            case_name: str = row[0]
+            category: str = row[1]
+            shape_prior: str = row[2]
 
-        if shape_prior.lower() == "true":
-            os.system(
-                f"python process_data.py --base_path {base_path} --case_name {case_name} --category {category} --shape_prior"
-            )
-        else:
-            os.system(
-                f"python process_data.py --base_path {base_path} --case_name {case_name} --category {category}"
-            )
+            if not os.path.exists(f"{base_path}/{case_name}"):
+                continue
+
+            if shape_prior.lower() == "true":
+                cmd: str = (
+                    f"python process_data.py --base_path {base_path} "
+                    f"--case_name {case_name} --category {category} --shape_prior"
+                )
+            else:
+                cmd = (
+                    f"python process_data.py --base_path {base_path} "
+                    f"--case_name {case_name} --category {category}"
+                )
+            os.system(cmd)
+
+
+if __name__ == "__main__":
+    process_all_cases("./data/different_types")
+

--- a/script_train.py
+++ b/script_train.py
@@ -1,23 +1,39 @@
-"""Utility script to run training for all scenes in ``base_path``."""
+"""Run training for each scene found in ``base_path``.
+
+The script scans all subfolders under ``base_path`` and launches
+``train_warp.py`` for the specified training frame in every scene's
+``split.json`` configuration.
+"""
 
 from __future__ import annotations
 
 import glob
-import os
 import json
+import os
+from typing import List
 
-base_path: str = "./data/different_types"
-dir_names = glob.glob(f"{base_path}/*")
-for dir_name in dir_names:
-    case_name = dir_name.split("/")[-1]
 
-    # Read the train test split
-    with open(f"{base_path}/{case_name}/split.json", "r") as f:
-        split = json.load(f)
+def run_training(base_path: str) -> None:
+    """Execute training for all available scenes."""
 
-    train_frame = split["train"][1]
+    dir_names: List[str] = glob.glob(f"{base_path}/*")
+    for dir_name in dir_names:
+        case_name: str = os.path.basename(dir_name)
 
-    # Execute the training script for the selected frame
-    os.system(
-        f"python train_warp.py --base_path {base_path} --case_name {case_name} --train_frame {train_frame}"
-    )
+        # Load the frame split information for this case.
+        with open(f"{base_path}/{case_name}/split.json", "r", encoding="utf-8") as f:
+            split: dict[str, list[int]] = json.load(f)
+
+        train_frame: int = split["train"][1]
+
+        # Invoke the actual training script for the selected frame.
+        cmd: str = (
+            f"python train_warp.py --base_path {base_path} "
+            f"--case_name {case_name} --train_frame {train_frame}"
+        )
+        os.system(cmd)
+
+
+if __name__ == "__main__":
+    run_training("./data/different_types")
+


### PR DESCRIPTION
## Summary
- add module documentation and type hints for script utilities
- improve evaluation scripts with clearer comments
- document data processing workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875161b64a0832e80a6579f3a25fbfb