### PR TITLE
Add documentation and type hints

### DIFF
--- a/data_process/README.md
+++ b/data_process/README.md
@@ -1,0 +1,44 @@
+# Data Processing Modules
+
+This folder contains utilities for pre-processing RGB-D sequences and generating meshes or point clouds used throughout the project.
+
+## Module Overview
+
+- `data_process_pcd.py` – Generates colored point clouds from depth images and camera poses.
+- `data_process_mask.py` – Filters segmentation masks and removes outliers in point clouds.
+- `match_pairs.py` – Performs image feature matching using SuperPoint and SuperGlue.
+- `shape_prior.py` – Example script demonstrating TRELLIS based mesh generation.
+- `utils/` – Helper functions for rendering, alignment and visualisation.
+
+Other scripts are used for tracking and segmentation and follow similar conventions.
+
+## Usage
+
+Most scripts expect a prepared dataset directory containing `color/`, `depth/` and `mask/` folders as well as metadata such as intrinsics and calibration files. Example command for point cloud generation:
+
+```bash
+python data_process/data_process_pcd.py --base_path PATH_TO_DATASET --case_name CASE
+```
+
+Feature matching on a set of images can be invoked via:
+
+```bash
+python data_process/match_pairs.py --help
+```
+
+### Dependencies
+
+The code relies on `open3d`, `numpy`, `opencv-python`, `torch` and `tqdm` among others. Please install the requirements of the repository before running the scripts.
+
+### Example
+
+```
+python data_process/shape_prior.py --img_path input.png --output_dir output
+```
+
+This command produces a mesh and gaussian representation of the input image using the TRELLIS pipeline.
+
+## Notes
+
+- Paths in arguments are assumed to be relative to the project root.
+- Some scripts may require CUDA capable hardware.

--- a/data_process/data_process_mask.py
+++ b/data_process/data_process_mask.py
@@ -1,3 +1,4 @@
+"""Post-process segmentation masks and remove outlier points."""
 # Process the mask data to filter out the outliers and generate the processed masks
 
 import numpy as np
@@ -27,19 +28,26 @@ CONTROLLER_NAME = args.controller_name
 processed_masks = {}
 
 
-def exist_dir(dir):
+def exist_dir(dir: str) -> None:
+    """Create directory if it does not exist."""
     if not os.path.exists(dir):
         os.makedirs(dir)
 
 
-def read_mask(mask_path):
-    # Convert the white mask into binary mask
+def read_mask(mask_path: str) -> np.ndarray:
+    """Load a binary mask image."""
     mask = cv2.imread(mask_path, cv2.IMREAD_GRAYSCALE)
-    mask = mask > 0
-    return mask
+    return mask > 0
 
 
-def process_pcd_mask(frame_idx, pcd_path, mask_path, mask_info, num_cam):
+def process_pcd_mask(
+    frame_idx: int,
+    pcd_path: str,
+    mask_path: str,
+    mask_info: dict,
+    num_cam: int,
+) -> tuple[o3d.geometry.PointCloud, o3d.geometry.PointCloud]:
+    """Process a single frame and return filtered object and controller point clouds."""
     global processed_masks
     processed_masks[frame_idx] = {}
 

--- a/data_process/data_process_pcd.py
+++ b/data_process/data_process_pcd.py
@@ -1,3 +1,4 @@
+"""Utilities for merging RGB-D frames into coloured point clouds."""
 # Merge the RGB-D data from multiple cameras into a single point cloud in world coordinate
 # Do some depth filtering to make the point cloud more clean
 
@@ -25,18 +26,19 @@ case_name = args.case_name
 
 # Use code from https://github.com/Jianghanxiao/Helper3D/blob/master/open3d_RGBD/src/camera/cameraHelper.py
 def getCamera(
-    transformation,
-    fx,
-    fy,
-    cx,
-    cy,
-    scale=1,
-    coordinate=True,
-    shoot=False,
-    length=4,
-    color=np.array([0, 1, 0]),
-    z_flip=False,
-):
+    transformation: np.ndarray,
+    fx: float,
+    fy: float,
+    cx: float,
+    cy: float,
+    scale: float = 1,
+    coordinate: bool = True,
+    shoot: bool = False,
+    length: float = 4,
+    color: np.ndarray = np.array([0, 1, 0]),
+    z_flip: bool = False,
+) -> list[o3d.geometry.Geometry]:
+    """Create a list of meshes representing the camera frustum."""
     # Return the camera and its corresponding frustum framework
     if coordinate:
         camera = o3d.geometry.TriangleMesh.create_coordinate_frame(size=scale)
@@ -83,9 +85,11 @@ def getCamera(
 
 # Use code from https://github.com/Jianghanxiao/Helper3D/blob/master/open3d_RGBD/src/model/pcdHelper.py
 def getPcdFromDepth(
-    depth,
-    intrinsic,
-):
+    depth: np.ndarray,
+    intrinsic: np.ndarray,
+) -> np.ndarray:
+    """Convert a depth map to a point cloud using the given intrinsic matrix."""
+
     # Depth in meters
     height, width = np.shape(depth)
 
@@ -113,7 +117,14 @@ def getPcdFromDepth(
     return points
 
 
-def get_pcd_from_data(path, frame_idx, num_cam, intrinsics, c2ws):
+def get_pcd_from_data(
+    path: str,
+    frame_idx: int,
+    num_cam: int,
+    intrinsics: np.ndarray,
+    c2ws: Sequence[np.ndarray],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Load depth/color frames and transform them into world coordinate point clouds."""
     total_points = []
     total_colors = []
     total_masks = []
@@ -168,7 +179,8 @@ def get_pcd_from_data(path, frame_idx, num_cam, intrinsics, c2ws):
     return total_points, total_colors, total_masks
 
 
-def exist_dir(dir):
+def exist_dir(dir: str) -> None:
+    """Create directory if it does not already exist."""
     if not os.path.exists(dir):
         os.makedirs(dir)
 

--- a/data_process/match_pairs.py
+++ b/data_process/match_pairs.py
@@ -43,6 +43,7 @@
 # %AUTHORS_END%
 # --------------------------------------------------------------------*/
 # %BANNER_END%
+"""Utilities for matching keypoints between images using SuperPoint and SuperGlue."""
 
 from pathlib import Path
 import argparse
@@ -65,25 +66,50 @@ torch.set_grad_enabled(False)
 
 
 def image_pair_matching(
-    input_images,
-    ref_image,
-    output_dir,
-    resize=[-1],
-    resize_float=False,
-    superglue="indoor",
-    max_keypoints=1024,
-    keypoint_threshold=0.005,
-    nms_radius=4,
-    sinkhorn_iterations=20,
-    match_threshold=0.2,
-    viz=False,
-    fast_viz=False,
-    cache=True,
-    show_keypoints=False,
-    viz_extension="png",
-    save=False,
-    viz_best=True,
-):
+    input_images: Sequence[np.ndarray],
+    ref_image: np.ndarray,
+    output_dir: str,
+    resize: Sequence[int] | None = [-1],
+    resize_float: bool = False,
+    superglue: str = "indoor",
+    max_keypoints: int = 1024,
+    keypoint_threshold: float = 0.005,
+    nms_radius: int = 4,
+    sinkhorn_iterations: int = 20,
+    match_threshold: float = 0.2,
+    viz: bool = False,
+    fast_viz: bool = False,
+    cache: bool = True,
+    show_keypoints: bool = False,
+    viz_extension: str = "png",
+    save: bool = False,
+    viz_best: bool = True,
+) -> tuple[int, dict]:
+    """Match features between input images and a reference image using SuperGlue.
+
+    Args:
+        input_images: List of image arrays to match.
+        ref_image: The reference image used for matching.
+        output_dir: Directory to save intermediate results.
+        resize: Optional resize setting for images.
+        resize_float: If True, resize using float precision.
+        superglue: Pretrained SuperGlue weights to use.
+        max_keypoints: Maximum keypoints detected per image.
+        keypoint_threshold: Detector threshold.
+        nms_radius: NMS radius for keypoints.
+        sinkhorn_iterations: Sinkhorn iterations in SuperGlue.
+        match_threshold: Matching threshold.
+        viz: Whether to save matching visualisations.
+        fast_viz: Use fast visualisation.
+        cache: Reuse cached matches if available.
+        show_keypoints: Display keypoints in visualisations.
+        viz_extension: File format for visualisation images.
+        save: Save match result arrays.
+        viz_best: Visualise the best matching pair.
+
+    Returns:
+        Tuple of index of the best pose and match dictionary for that pose.
+    """
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print('Running inference on device "{}"'.format(device))

--- a/data_process/shape_prior.py
+++ b/data_process/shape_prior.py
@@ -1,3 +1,4 @@
+"""Generate shape priors using the TRELLIS pipeline."""
 import os
 
 # os.environ['ATTN_BACKEND'] = 'xformers'   # Can be 'flash-attn' or 'xformers', default is 'flash-attn'
@@ -24,10 +25,14 @@ img_path = args.img_path
 output_dir = args.output_dir
 
 # Load a pipeline from a model folder or a Hugging Face model hub.
+# Initialize the pretrained TRELLIS pipeline
+
 pipeline = TrellisImageTo3DPipeline.from_pretrained("JeffreyXiang/TRELLIS-image-large")
 pipeline.cuda()
 
 final_im = Image.open(img_path).convert("RGBA")
+# Execute the conversion from image to 3D representation
+
 assert not np.all(np.array(final_im)[:, :, 3] == 255)
 
 # Run the pipeline

--- a/data_process/utils/align_util.py
+++ b/data_process/utils/align_util.py
@@ -1,3 +1,5 @@
+"""Alignment utilities for projecting points and rendering meshes."""
+
 import numpy as np
 import torch
 import trimesh

--- a/data_process/utils/visualizer.py
+++ b/data_process/utils/visualizer.py
@@ -3,6 +3,7 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+"""Utility classes for visualizing point clouds and depth data."""
 
 import os
 import numpy as np


### PR DESCRIPTION
## Summary
- add a documentation README for data_process scripts
- document mask/pcd utilities and add type hints
- improve match_pairs documentation and signatures
- add brief module docstrings for shape_prior and utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687671d4365c832eb75cb50d6ea93fc6