### PR TITLE
Fix dynamic rendering script for white background

### DIFF
--- a/gs_run_simulate_white.sh
+++ b/gs_run_simulate_white.sh
@@ -28,7 +28,7 @@ for scene_name in "${scenes[@]}"; do
         -s ./data/gaussian_data/${scene_name} \
         -m ./gaussian_output/${scene_name}/${exp_name} \
         --name ${scene_name} \
-        --white_background
+        --white_background \
         --output_dir ${output_dir}/${scene_name}
 
     for view_name in "${views[@]}"; do


### PR DESCRIPTION
## Summary
- fix newline in `gs_run_simulate_white.sh` so the `--output_dir` argument is passed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ccfc7a7bc832e97bc7f34d962f207