### PR TITLE
Fix Sequence import in match_pairs

### DIFF
--- a/data_process/match_pairs.py
+++ b/data_process/match_pairs.py
@@ -53,6 +53,7 @@ import matplotlib.cm as cm
 import torch
 import sys
 import os
+from typing import Sequence
 
 sys.path.append(os.getcwd())
 from models.matching import Matching


### PR DESCRIPTION
## Summary
- add missing `Sequence` import in `data_process/match_pairs.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880250005dc832ea1069ff744b52615